### PR TITLE
Fix workflow event logic

### DIFF
--- a/.github/workflows/oci-lz-tests.yml
+++ b/.github/workflows/oci-lz-tests.yml
@@ -2,14 +2,16 @@ name: Landing Zone CICD Test Suite
 
 on:
   workflow_dispatch:
-  push:
-    branches: 
-    - master
-    - cicdtest
+    inputs:
+      deploy_integration:
+        type: boolean
+        description: "Deploy to Integration Environment?"
+        required: true
+        default: false
   pull_request:
     branches: 
     - master
-    - cicdtest
+    - integration
     types:
     - closed
     - opened
@@ -68,7 +70,7 @@ jobs:
   integration-plan:
     runs-on: ubuntu-latest
     needs: unittests
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true || (github.event_name == "workflow_dispatch" && github.event.inputs.deploy_integration == true)
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.9


### PR DESCRIPTION
change second branch name to 'integration'
Allow integration deploy on manual workflow run.